### PR TITLE
Hybrid Schrödinger-Feynman Simulation Preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14...3.19)
 # project definition
 project(DDPackage
         LANGUAGES CXX
-        VERSION 2.0.1
+        VERSION 2.0.2
         DESCRIPTION "JKQ decision diagram package tailored to quantum computing")
 
 # enable organization of targets into folders

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Alwin Zulehner, Stefan Hillmich, Lukas Burgholzer and Robert Wille
+Copyright (c) 2021 Hartwig Bauer, Lukas Burgholzer, Thomas Grurl, Stefan Hillmich, Robert Wille, and Alwin Zulehner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ A small example shows how to create set a single qubit in superposition.
 
 ```c++
 #include <memory>
-#include "DDpackage.h"
-#include "GateMatrixDefinitions.h"
+#include "dd/Package.hpp"
 
-auto dd = std::make_unique<dd::Package>(); // Create new package instance
+auto dd = std::make_unique<dd::Package>(1); // Create new package instance capable of handling a single qubit
 auto zero_state = dd->makeZeroState(1) ; // zero_state = |0>
 
 /* Creating a DD requires the following inputs:

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -194,6 +194,17 @@ namespace dd {
 
             return ss.str();
         }
+
+        ComplexValue& operator+=(const ComplexValue& rhs) {
+            r += rhs.r;
+            i += rhs.i;
+            return *this;
+        }
+
+        friend ComplexValue operator+(ComplexValue lhs, const ComplexValue& rhs) {
+            lhs += rhs;
+            return lhs;
+        }
     };
 
     inline std::ostream& operator<<(std::ostream& os, const ComplexValue& c) {

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -644,12 +644,7 @@ namespace dd {
     }
     template<class Edge>
     static void serialize(const Edge& basic, const std::string& outputFilename, bool writeBinary = false) {
-        std::ofstream ofs;
-        if (writeBinary) {
-            ofs = std::ofstream(outputFilename, std::ios::binary);
-        } else {
-            ofs = std::ofstream(outputFilename);
-        }
+        std::ofstream ofs = std::ofstream(outputFilename, std::ios::binary);
 
         if (!ofs.good()) {
             throw std::invalid_argument("Cannot open file: " + outputFilename);

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -644,7 +644,12 @@ namespace dd {
     }
     template<class Edge>
     static void serialize(const Edge& basic, const std::string& outputFilename, bool writeBinary = false) {
-        std::ofstream ofs(outputFilename);
+        std::ofstream ofs;
+        if (writeBinary) {
+            ofs = std::ofstream(outputFilename, std::ios::binary);
+        } else {
+            ofs = std::ofstream(outputFilename);
+        }
 
         if (!ofs.good()) {
             throw std::invalid_argument("Cannot open file: " + outputFilename);

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -138,7 +138,7 @@ namespace dd {
         return os;
     }
 
-    static std::ostream& modernNode(const Package::mEdge& e, std::ostream& os) {
+    [[maybe_unused]] static std::ostream& modernNode(const Package::mEdge& e, std::ostream& os) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[label=<";
         os << R"(<font point-size="10"><table border="1" cellspacing="0" cellpadding="2" style="rounded">)";
@@ -155,7 +155,7 @@ namespace dd {
         os << "</table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    static std::ostream& modernNode(const Package::vEdge& e, std::ostream& os) {
+    [[maybe_unused]] static std::ostream& modernNode(const Package::vEdge& e, std::ostream& os) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[label=<";
         os << R"(<font point-size="8"><table border="1" cellspacing="0" cellpadding="0" style="rounded">)";
@@ -165,7 +165,7 @@ namespace dd {
         os << "</tr></table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    static std::ostream& classicNode(const Package::mEdge& e, std::ostream& os) {
+    [[maybe_unused]] static std::ostream& classicNode(const Package::mEdge& e, std::ostream& os) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[shape=circle, width=0.53, fixedsize=true, label=<";
         os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
@@ -203,7 +203,7 @@ namespace dd {
         os << "<td></td></tr></table></font>>,tooltip=\"q" << static_cast<std::size_t>(e.p->v) << "\"]\n";
         return os;
     }
-    static std::ostream& classicNode(const Package::vEdge& e, std::ostream& os) {
+    [[maybe_unused]] static std::ostream& classicNode(const Package::vEdge& e, std::ostream& os) {
         auto nodelabel = (reinterpret_cast<std::uintptr_t>(e.p) & 0x001fffffU) >> 1U; // this allows for 2^20 (roughly 1e6) unique nodes
         os << nodelabel << "[shape=circle, width=0.46, fixedsize=true, label=<";
         os << R"(<font point-size="6"><table border="0" cellspacing="0" cellpadding="0">)";
@@ -249,7 +249,7 @@ namespace dd {
         return os;
     }
 
-    static std::ostream& bwEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false) {
+    [[maybe_unused]] static std::ostream& bwEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -288,7 +288,7 @@ namespace dd {
 
         return os;
     }
-    static std::ostream& bwEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false) {
+    [[maybe_unused]] static std::ostream& bwEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -312,7 +312,7 @@ namespace dd {
 
         return os;
     }
-    static std::ostream& coloredEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const Package::mEdge& from, const Package::mEdge& to, short idx, std::ostream& os, bool edgeLabels = false, bool classic = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -349,7 +349,7 @@ namespace dd {
 
         return os;
     }
-    static std::ostream& coloredEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false) {
+    [[maybe_unused]] static std::ostream& coloredEdge(const Package::vEdge& from, const Package::vEdge& to, short idx, std::ostream& os, bool edgeLabels = false, [[maybe_unused]] bool classic = false) {
         auto fromlabel = (reinterpret_cast<std::uintptr_t>(from.p) & 0x001fffffU) >> 1U;
         auto tolabel   = (reinterpret_cast<std::uintptr_t>(to.p) & 0x001fffffU) >> 1U;
 
@@ -486,7 +486,7 @@ namespace dd {
     }
 
     template<class Edge>
-    static void export2Dot(Edge basic, const std::string& outputFilename, bool colored = true, bool edgeLabels = false, bool classic = false, bool memory = false, bool show = true) {
+    [[maybe_unused]] static void export2Dot(Edge basic, const std::string& outputFilename, bool colored = true, bool edgeLabels = false, bool classic = false, bool memory = false, bool show = true) {
         std::ofstream init(outputFilename);
         toDot(basic, init, colored, edgeLabels, classic, memory);
         init.close();
@@ -629,7 +629,7 @@ namespace dd {
             }
         }
     }
-    static void serialize(const Package::mEdge& basic, std::ostream& os, bool writeBinary = false) {
+    [[maybe_unused]] static void serialize(const Package::mEdge& basic, std::ostream& os, bool writeBinary = false) {
         if (writeBinary) {
             os.write(reinterpret_cast<const char*>(&SERIALIZATION_VERSION), sizeof(decltype(SERIALIZATION_VERSION)));
             basic.w.writeBinary(os);

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -504,7 +504,7 @@ namespace dd {
     /// Note: do not rely on the binary format being portable across different architectures/platforms
     ///
 
-    static void serialize(const Package::vEdge& basic, std::ostream& os, bool writeBinary = false) {
+    [[maybe_unused]] static void serialize(const Package::vEdge& basic, std::ostream& os, bool writeBinary = false) {
         if (writeBinary) {
             os.write(reinterpret_cast<const char*>(&SERIALIZATION_VERSION), sizeof(decltype(SERIALIZATION_VERSION)));
             basic.w.writeBinary(os);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -190,21 +190,21 @@ namespace dd {
         }
 
         // generate |0...0> with n qubits
-        vEdge makeZeroState(QubitCount n) {
-            assert(n <= nqubits);
+        vEdge makeZeroState(QubitCount n, std::size_t start = 0) {
+            assert(n + start <= nqubits);
 
             auto f = vEdge::one;
-            for (std::size_t p = 0; p < n; p++) {
+            for (std::size_t p = start; p < n + start; p++) {
                 f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
             }
             return f;
         }
         // generate computational basis state |i> with n qubits
-        vEdge makeBasisState(QubitCount n, const std::vector<bool>& state) {
-            assert(n <= nqubits);
+        vEdge makeBasisState(QubitCount n, const std::vector<bool>& state, std::size_t start = 0) {
+            assert(n + start <= nqubits);
 
             auto f = vEdge::one;
-            for (std::size_t p = 0; p < n; ++p) {
+            for (std::size_t p = start; p < n + start; ++p) {
                 if (state[p] == 0) {
                     f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
                 } else {
@@ -214,15 +214,15 @@ namespace dd {
             return f;
         }
         // generate general basis state with n qubits
-        vEdge makeBasisState(QubitCount n, const std::vector<BasisStates>& state) {
-            assert(n <= nqubits);
+        vEdge makeBasisState(QubitCount n, const std::vector<BasisStates>& state, std::size_t start = 0) {
+            assert(n + start <= nqubits);
 
             if (state.size() < n) {
                 throw std::invalid_argument("Insufficient qubit states provided. Requested " + std::to_string(n) + ", but received " + std::to_string(state.size()));
             }
 
             auto f = vEdge::one;
-            for (std::size_t p = 0; p < n; ++p) {
+            for (std::size_t p = start; p < n + start; ++p) {
                 switch (state[p]) {
                     case BasisStates::zero:
                         f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
@@ -353,17 +353,14 @@ namespace dd {
         }
 
         // build matrix representation for a single gate on an n-qubit circuit
-        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, Qubit target) {
-            return makeGateDD(mat, n, Controls{}, target);
+        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, Qubit target, std::size_t start = 0) {
+            return makeGateDD(mat, n, Controls{}, target, start);
         }
-        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, const Control& control, Qubit target) {
-            return makeGateDD(mat, n, Controls{control}, target);
+        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, const Control& control, Qubit target, std::size_t start = 0) {
+            return makeGateDD(mat, n, Controls{control}, target, start);
         }
-        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, Qubit control, Qubit target) {
-            return makeGateDD(mat, n, Controls{{control}}, target);
-        }
-        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, const Controls& controls, Qubit target) {
-            assert(n <= nqubits);
+        mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, const Controls& controls, Qubit target, std::size_t start = 0) {
+            assert(n + start <= nqubits);
 
             std::array<mEdge, NEDGE> em{};
             auto                     it = controls.begin();
@@ -376,16 +373,16 @@ namespace dd {
             }
 
             //process lines below target
-            Qubit z = 0;
+            auto z = static_cast<Qubit>(start);
             for (; z < target; z++) {
                 for (auto i1 = 0U; i1 < RADIX; i1++) {
                     for (auto i2 = 0U; i2 < RADIX; i2++) {
                         auto i = i1 * RADIX + i2;
                         if (it != controls.end() && it->qubit == z) {
                             if (it->type == Control::Type::neg) { // neg. control
-                                em[i] = makeDDNode(z, std::array{em[i], mEdge::zero, mEdge::zero, (i1 == i2) ? makeIdent(z) : mEdge::zero});
+                                em[i] = makeDDNode(z, std::array{em[i], mEdge::zero, mEdge::zero, (i1 == i2) ? makeIdent(static_cast<Qubit>(start), static_cast<Qubit>(z - 1)) : mEdge::zero});
                             } else { // pos. control
-                                em[i] = makeDDNode(z, std::array{(i1 == i2) ? makeIdent(z) : mEdge::zero, mEdge::zero, mEdge::zero, em[i]});
+                                em[i] = makeDDNode(z, std::array{(i1 == i2) ? makeIdent(static_cast<Qubit>(start), static_cast<Qubit>(z - 1)) : mEdge::zero, mEdge::zero, mEdge::zero, em[i]});
                             }
                         } else { // not connected
                             em[i] = makeDDNode(z, std::array{em[i], mEdge::zero, mEdge::zero, em[i]});
@@ -401,13 +398,13 @@ namespace dd {
             auto e = makeDDNode(z, em);
 
             //process lines above target
-            for (; z < static_cast<Qubit>(n - 1); z++) {
+            for (; z < static_cast<Qubit>(n - 1 + start); z++) {
                 auto q = static_cast<Qubit>(z + 1);
                 if (it != controls.end() && it->qubit == q) {
                     if (it->type == Control::Type::neg) { // neg. control
-                        e = makeDDNode(q, std::array{e, mEdge::zero, mEdge::zero, makeIdent(q)});
+                        e = makeDDNode(q, std::array{e, mEdge::zero, mEdge::zero, makeIdent(static_cast<Qubit>(start), static_cast<Qubit>(q - 1))});
                     } else { // pos. control
-                        e = makeDDNode(q, std::array{makeIdent(q), mEdge::zero, mEdge::zero, e});
+                        e = makeDDNode(q, std::array{makeIdent(static_cast<Qubit>(start), static_cast<Qubit>(q - 1)), mEdge::zero, mEdge::zero, e});
                     }
                     ++it;
                 } else { // not connected
@@ -417,57 +414,57 @@ namespace dd {
             return e;
         }
 
-        mEdge makeSWAPDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1) {
+        mEdge makeSWAPDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1, std::size_t start = 0) {
             auto c = controls;
             c.insert(Control{target0});
-            mEdge e = makeGateDD(Xmat, n, c, target1);
+            mEdge e = makeGateDD(Xmat, n, c, target1, start);
             c.erase(Control{target0});
             c.insert(Control{target1});
-            e = multiply(e, multiply(makeGateDD(Xmat, n, c, target0), e));
+            e = multiply(e, multiply(makeGateDD(Xmat, n, c, target0, start), e));
             return e;
         }
 
-        mEdge makePeresDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1) {
+        mEdge makePeresDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1, std::size_t start = 0) {
             auto c = controls;
             c.insert(Control{target1});
-            mEdge e = makeGateDD(Xmat, n, c, target0);
-            e       = multiply(makeGateDD(Xmat, n, controls, target1), e);
+            mEdge e = makeGateDD(Xmat, n, c, target0, start);
+            e       = multiply(makeGateDD(Xmat, n, controls, target1, start), e);
             return e;
         }
 
-        mEdge makePeresdagDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1) {
-            mEdge e = makeGateDD(Xmat, n, controls, target1);
+        mEdge makePeresdagDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1, std::size_t start = 0) {
+            mEdge e = makeGateDD(Xmat, n, controls, target1, start);
             auto  c = controls;
             c.insert(Control{target1});
-            e = multiply(makeGateDD(Xmat, n, c, target0), e);
+            e = multiply(makeGateDD(Xmat, n, c, target0, start), e);
             return e;
         }
 
-        mEdge makeiSWAPDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1) {
-            mEdge e = makeGateDD(Smat, n, controls, target1);              // S q[1]
-            e       = multiply(e, makeGateDD(Smat, n, controls, target0)); // S q[0]
-            e       = multiply(e, makeGateDD(Hmat, n, controls, target0)); // H q[0]
+        mEdge makeiSWAPDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1, std::size_t start = 0) {
+            mEdge e = makeGateDD(Smat, n, controls, target1, start);              // S q[1]
+            e       = multiply(e, makeGateDD(Smat, n, controls, target0, start)); // S q[0]
+            e       = multiply(e, makeGateDD(Hmat, n, controls, target0, start)); // H q[0]
             auto c  = controls;
             c.insert(Control{target0});
-            e = multiply(e, makeGateDD(Xmat, n, c, target1)); // CX q[0], q[1]
+            e = multiply(e, makeGateDD(Xmat, n, c, target1, start)); // CX q[0], q[1]
             c.erase(Control{target0});
             c.insert(Control{target1});
-            e = multiply(e, makeGateDD(Xmat, n, c, target0));        // CX q[1], q[0]
-            e = multiply(e, makeGateDD(Hmat, n, controls, target1)); // H q[1]
+            e = multiply(e, makeGateDD(Xmat, n, c, target0, start));        // CX q[1], q[0]
+            e = multiply(e, makeGateDD(Hmat, n, controls, target1, start)); // H q[1]
             return e;
         }
 
-        mEdge makeiSWAPinvDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1) {
-            mEdge e = makeGateDD(Hmat, n, controls, target1); // H q[1]
+        mEdge makeiSWAPinvDD(QubitCount n, const Controls& controls, Qubit target0, Qubit target1, std::size_t start = 0) {
+            mEdge e = makeGateDD(Hmat, n, controls, target1, start); // H q[1]
             auto  c = controls;
             c.insert(Control{target1});
-            e = multiply(e, makeGateDD(Xmat, n, c, target0)); // CX q[1], q[0]
+            e = multiply(e, makeGateDD(Xmat, n, c, target0, start)); // CX q[1], q[0]
             c.erase(Control{target1});
             c.insert(Control{target0});
-            e = multiply(e, makeGateDD(Xmat, n, c, target1));           // CX q[0], q[1]
-            e = multiply(e, makeGateDD(Hmat, n, controls, target0));    // H q[0]
-            e = multiply(e, makeGateDD(Sdagmat, n, controls, target0)); // Sdag q[0]
-            e = multiply(e, makeGateDD(Sdagmat, n, controls, target1)); // Sdag q[1]
+            e = multiply(e, makeGateDD(Xmat, n, c, target1, start));           // CX q[0], q[1]
+            e = multiply(e, makeGateDD(Hmat, n, controls, target0, start));    // H q[0]
+            e = multiply(e, makeGateDD(Sdagmat, n, controls, target0, start)); // Sdag q[0]
+            e = multiply(e, makeGateDD(Sdagmat, n, controls, target1, start)); // Sdag q[1]
             return e;
         }
 
@@ -590,6 +587,51 @@ namespace dd {
             }
 
             return l;
+        }
+
+        template<class Node>
+        Edge<Node> deleteEdge(const Edge<Node>& e, dd::Qubit v, std::size_t edgeIdx) {
+            std::unordered_map<Node*, Edge<Node>> nodes{};
+            return deleteEdge(e, v, edgeIdx, nodes);
+        }
+
+    private:
+        template<class Node>
+        Edge<Node> deleteEdge(const Edge<Node>& e, dd::Qubit v, std::size_t edgeIdx, std::unordered_map<Node*, Edge<Node>>& nodes) {
+            if (e.p == nullptr || e.isTerminal()) {
+                return e;
+            }
+
+            const auto& nodeit = nodes.find(e.p);
+            Edge<Node>  newedge{};
+            if (nodeit != nodes.end()) {
+                newedge = nodeit->second;
+            } else {
+                constexpr std::size_t     N = std::tuple_size_v<decltype(e.p->e)>;
+                std::array<Edge<Node>, N> edges{};
+                if (e.p->v == v) {
+                    for (std::size_t i = 0; i < N; i++) {
+                        edges[i] = i == edgeIdx ? Edge<Node>::zero : e.p->e[i]; // optimization -> node cannot occur below again, since dd is assumed to be free
+                    }
+                } else {
+                    for (std::size_t i = 0; i < N; i++) {
+                        edges[i] = deleteEdge(e.p->e[i], v, edgeIdx, nodes);
+                    }
+                }
+
+                newedge    = makeDDNode(e.p->v, edges);
+                nodes[e.p] = newedge;
+            }
+
+            if (newedge.w.approximatelyOne()) {
+                newedge.w = e.w;
+            } else {
+                auto w = cn.getTemporary();
+                dd::ComplexNumbers::mul(w, newedge.w, e.w);
+                newedge.w = cn.lookup(w);
+            }
+
+            return newedge;
         }
 
         ///
@@ -816,7 +858,7 @@ namespace dd {
         [[nodiscard]] ComputeTable<Edge<LeftOperandNode>, Edge<RightOperandNode>, CachedEdge<RightOperandNode>>& getMultiplicationComputeTable();
 
         template<class LeftOperand, class RightOperand>
-        RightOperand multiply(const LeftOperand& x, const RightOperand& y) {
+        RightOperand multiply(const LeftOperand& x, const RightOperand& y, dd::Qubit start = 0) {
             [[maybe_unused]] const auto before = cn.cacheCount();
 
             Qubit var = -1;
@@ -827,7 +869,7 @@ namespace dd {
                 var = y.p->v;
             }
 
-            auto e = multiply2(x, y, var);
+            auto e = multiply2(x, y, var, start);
 
             if (e.w != Complex::zero && e.w != Complex::one) {
                 cn.returnToCache(e.w);
@@ -842,7 +884,7 @@ namespace dd {
 
     private:
         template<class LeftOperandNode, class RightOperandNode>
-        Edge<RightOperandNode> multiply2(const Edge<LeftOperandNode>& x, const Edge<RightOperandNode>& y, Qubit var) {
+        Edge<RightOperandNode> multiply2(const Edge<LeftOperandNode>& x, const Edge<RightOperandNode>& y, Qubit var, Qubit start = 0) {
             using LEdge      = Edge<LeftOperandNode>;
             using REdge      = Edge<RightOperandNode>;
             using ResultEdge = Edge<RightOperandNode>;
@@ -854,7 +896,7 @@ namespace dd {
                 return ResultEdge::zero;
             }
 
-            if (var == -1) {
+            if (var == start - 1) {
                 return ResultEdge::terminal(cn.mulCached(x.w, y.w));
             }
 
@@ -888,7 +930,7 @@ namespace dd {
                     if constexpr (N == NEDGE) {
                         // additionally check if y is the identity in case of matrix multiplication
                         if (y.p->ident) {
-                            e = makeIdent(0, var);
+                            e = makeIdent(start, var);
                         } else {
                             e = yCopy;
                         }
@@ -943,7 +985,7 @@ namespace dd {
                             e2 = yCopy;
                         }
 
-                        auto m = multiply2(e1, e2, static_cast<Qubit>(var - 1));
+                        auto m = multiply2(e1, e2, static_cast<Qubit>(var - 1), start);
 
                         if (k == 0 || edge[idx].w == Complex::zero) {
                             edge[idx] = m;
@@ -1071,8 +1113,8 @@ namespace dd {
         [[nodiscard]] ComputeTable<Edge<Node>, Edge<Node>, CachedEdge<Node>, 4096>& getKroneckerComputeTable();
 
         template<class Edge>
-        Edge kronecker(const Edge& x, const Edge& y) {
-            auto e = kronecker2(x, y);
+        Edge kronecker(const Edge& x, const Edge& y, bool incIdx = true) {
+            auto e = kronecker2(x, y, incIdx);
 
             if (e.w != Complex::zero && e.w != Complex::one) {
                 cn.returnToCache(e.w);
@@ -1091,8 +1133,8 @@ namespace dd {
 
     private:
         template<class Node>
-        Edge<Node> kronecker2(const Edge<Node>& x, const Edge<Node>& y) {
-            if (x.w.approximatelyZero())
+        Edge<Node> kronecker2(const Edge<Node>& x, const Edge<Node>& y, bool incIdx = true) {
+            if (x.w.approximatelyZero() || y.w.approximatelyZero())
                 return Edge<Node>::zero;
 
             if (x.isTerminal()) {
@@ -1115,9 +1157,11 @@ namespace dd {
             // special case handling for matrices
             if constexpr (N == NEDGE) {
                 if (x.p->ident) {
-                    auto e = makeDDNode(static_cast<Qubit>(y.p->v + 1), std::array{y, Edge<Node>::zero, Edge<Node>::zero, y});
+                    auto idx = incIdx ? static_cast<Qubit>(y.p->v + 1) : y.p->v;
+                    auto e   = makeDDNode(idx, std::array{y, Edge<Node>::zero, Edge<Node>::zero, y});
                     for (auto i = 0; i < x.p->v; ++i) {
-                        e = makeDDNode(static_cast<Qubit>(e.p->v + 1), std::array{e, Edge<Node>::zero, Edge<Node>::zero, e});
+                        idx = incIdx ? static_cast<Qubit>(e.p->v + 1) : e.p->v;
+                        e   = makeDDNode(idx, std::array{e, Edge<Node>::zero, Edge<Node>::zero, e});
                     }
 
                     e.w = cn.getCached(CTEntry::val(y.w.r), CTEntry::val(y.w.i));
@@ -1128,10 +1172,11 @@ namespace dd {
 
             std::array<Edge<Node>, N> edge{};
             for (auto i = 0U; i < N; ++i) {
-                edge[i] = kronecker2(x.p->e[i], y);
+                edge[i] = kronecker2(x.p->e[i], y, incIdx);
             }
 
-            auto e = makeDDNode(static_cast<Qubit>(y.p->v + x.p->v + 1), edge, true);
+            auto idx = incIdx ? static_cast<Qubit>(y.p->v + x.p->v + 1) : x.p->v;
+            auto e   = makeDDNode(idx, edge, true);
             ComplexNumbers::mul(e.w, e.w, x.w);
             computeTable.insert(x, y, {e.p, e.w});
             return e;
@@ -1234,7 +1279,7 @@ namespace dd {
         // create n-qubit identity DD. makeIdent(n) === makeIdent(0, n-1)
         mEdge makeIdent(QubitCount n) { return makeIdent(0, static_cast<Qubit>(n - 1)); }
         mEdge makeIdent(Qubit leastSignificantQubit, Qubit mostSignificantQubit) {
-            if (mostSignificantQubit < 0)
+            if (mostSignificantQubit < leastSignificantQubit)
                 return mEdge::one;
 
             if (leastSignificantQubit == 0 && IdTable[mostSignificantQubit].p != nullptr) {
@@ -1708,6 +1753,182 @@ namespace dd {
             if (!e.p->e[3].w.approximatelyZero())
                 getMatrix(e.p->e[3], c, x, y, mat);
             cn.returnToCache(c);
+        }
+
+        void exportAmplitudesRec(const dd::Package::vEdge& node, std::ostream& oss, const std::string& path, Complex& amplitude, dd::QubitCount level, bool binary = false) {
+            if (node.isTerminal()) {
+                auto amp = cn.getTemporary();
+                dd::ComplexNumbers::mul(amp, amplitude, node.w);
+                for (std::size_t i = 0; i < (1UL << level); i++) {
+                    if (binary) {
+                        amp.writeBinary(oss);
+                    } else {
+                        oss << amp.toString(false, 16) << "\n";
+                    }
+                }
+
+                return;
+            }
+
+            auto a = cn.mulCached(amplitude, node.w);
+            exportAmplitudesRec(node.p->e[0], oss, path + "0", a, level - 1, binary);
+            exportAmplitudesRec(node.p->e[1], oss, path + "1", a, level - 1, binary);
+            cn.returnToCache(a);
+        }
+        void exportAmplitudes(const dd::Package::vEdge& node, std::ostream& oss, dd::QubitCount nq, bool binary = false) {
+            if (node.isTerminal()) {
+                // TODO special treatment
+                return;
+            }
+            auto weight = cn.getCached(1., 0.);
+            exportAmplitudesRec(node, oss, "", weight, nq, binary);
+            cn.returnToCache(weight);
+        }
+        void exportAmplitudes(const dd::Package::vEdge& node, const std::string& outputFilename, dd::QubitCount nq, bool binary = false) {
+            std::ofstream      init(outputFilename);
+            std::ostringstream oss{};
+
+            exportAmplitudes(node, oss, nq, binary);
+
+            init << oss.str() << std::flush;
+            init.close();
+        }
+
+        void exportAmplitudesRec(const dd::Package::vEdge& node, std::vector<ComplexValue>& amplitudes, Complex& amplitude, dd::QubitCount level, std::size_t idx) {
+            if (node.isTerminal()) {
+                auto amp = cn.getTemporary();
+                dd::ComplexNumbers::mul(amp, amplitude, node.w);
+                idx <<= level;
+                for (std::size_t i = 0; i < (1UL << level); i++) {
+                    amplitudes[idx++] = dd::ComplexValue{dd::ComplexTable<>::Entry::val(amp.r), dd::ComplexTable<>::Entry::val(amp.i)};
+                }
+
+                return;
+            }
+
+            auto a = cn.mulCached(amplitude, node.w);
+            exportAmplitudesRec(node.p->e[0], amplitudes, a, level - 1, idx << 1);
+            exportAmplitudesRec(node.p->e[1], amplitudes, a, level - 1, (idx << 1) | 1);
+            cn.returnToCache(a);
+        }
+        void exportAmplitudes(const dd::Package::vEdge& node, std::vector<ComplexValue>& amplitudes, dd::QubitCount nq) {
+            if (node.isTerminal()) {
+                // TODO special treatment
+                return;
+            }
+            auto weight = cn.getCached(1., 0.);
+            exportAmplitudesRec(node, amplitudes, weight, nq, 0);
+            cn.returnToCache(weight);
+        }
+
+        void addAmplitudesRec(const dd::Package::vEdge& node, std::vector<ComplexValue>& amplitudes, ComplexValue& amplitude, dd::QubitCount level, std::size_t idx) {
+            auto         ar = dd::ComplexTable<>::Entry::val(node.w.r);
+            auto         ai = dd::ComplexTable<>::Entry::val(node.w.i);
+            ComplexValue amp{ar * amplitude.r - ai * amplitude.i, ar * amplitude.i + ai * amplitude.r};
+
+            if (node.isTerminal()) {
+                idx <<= level;
+                for (std::size_t i = 0; i < (1UL << level); i++) {
+                    auto temp         = dd::ComplexValue{amp.r + amplitudes[idx].r, amp.i + amplitudes[idx].i};
+                    amplitudes[idx++] = temp;
+                }
+
+                return;
+            }
+
+            addAmplitudesRec(node.p->e[0], amplitudes, amp, level - 1, idx << 1);
+            addAmplitudesRec(node.p->e[1], amplitudes, amp, level - 1, idx << 1 | 1);
+        }
+        void addAmplitudes(const dd::Package::vEdge& node, std::vector<ComplexValue>& amplitudes, dd::QubitCount nq) {
+            if (node.isTerminal()) {
+                // TODO special treatment
+                return;
+            }
+            ComplexValue a{1., 0.};
+            addAmplitudesRec(node, amplitudes, a, nq, 0);
+        }
+
+        // transfers a decision diagram from another package to this package
+        template<class Edge>
+        Edge transfer(Edge& original) {
+            // POST ORDER TRAVERSAL USING ONE STACK   https://www.geeksforgeeks.org/iterative-postorder-traversal-using-stack/
+            Edge              root{};
+            std::stack<Edge*> stack;
+
+            std::unordered_map<decltype(original.p)*, decltype(original.p)*> mapped_node{};
+
+            Edge* node = &original;
+            if (!node->isTerminal()) {
+                constexpr std::size_t N = std::tuple_size_v<decltype(original.p->e)>;
+                do {
+                    while (node != nullptr && !node->isTerminal()) {
+                        for (short i = N - 1; i > 0; --i) {
+                            auto& edge = node->p->e[i];
+                            if (edge.isTerminal()) {
+                                continue;
+                            }
+                            if (edge.w.approximatelyZero()) {
+                                continue;
+                            }
+                            if (mapped_node.find(edge.p) != mapped_node.end()) {
+                                continue;
+                            }
+
+                            // non-zero edge to be included
+                            stack.push(&edge);
+                        }
+                        stack.push(node);
+                        node = &node->p->e[0];
+                    }
+                    node = stack.top();
+                    stack.pop();
+
+                    bool hasChild = false;
+                    for (std::size_t i = 1; i < N && !hasChild; ++i) {
+                        auto& edge = node->p->e[i];
+                        if (edge.w.approximatelyZero()) {
+                            continue;
+                        }
+                        if (mapped_node.find(edge.p) != mapped_node.end()) {
+                            continue;
+                        }
+                        hasChild = edge.p == stack.top()->p;
+                    }
+
+                    if (hasChild) {
+                        Edge* temp = stack.top();
+                        stack.pop();
+                        stack.push(node);
+                        node = temp;
+                    } else {
+                        if (mapped_node.find(node->p) != mapped_node.end()) {
+                            node = nullptr;
+                            continue;
+                        }
+                        std::array<Edge, N> edges{};
+                        for (std::size_t i = 0; i < N; i++) {
+                            if (node->p->e[i].isTerminal()) {
+                                edges[i].p = node->p->e[i].p;
+                            } else {
+                                edges[i].p = mapped_node[node->p->e[i].p];
+                            }
+                            edges[i].w = cn.lookup(node->p->e[i].w);
+                        }
+                        root                 = makeDDNode(node->p->v, edges);
+                        mapped_node[node->p] = root.p;
+                        node                 = nullptr;
+                    }
+                } while (!stack.empty());
+
+                auto w = cn.getCached(dd::ComplexTable<>::Entry::val(original.w.r), dd::ComplexTable<>::Entry::val(original.w.i));
+                dd::ComplexNumbers::mul(w, root.w, w);
+                root.w = cn.lookup(w);
+                cn.returnToCache(w);
+            } else {
+                root.p = original.p; // terminal -> static
+                root.w = cn.lookup(original.w);
+            }
+            return root;
         }
 
         ///

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1855,7 +1855,7 @@ namespace dd {
             Edge              root{};
             std::stack<Edge*> stack;
 
-            std::unordered_map<decltype(original.p)*, decltype(original.p)*> mapped_node{};
+            std::unordered_map<decltype(original.p), decltype(original.p)> mapped_node{};
 
             Edge* node = &original;
             if (!node->isTerminal()) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2034,7 +2034,12 @@ namespace dd {
 
         template<class Node, class Edge = Edge<Node>>
         Edge deserialize(const std::string& inputFilename, bool readBinary) {
-            auto ifs = std::ifstream(inputFilename);
+            std::ifstream ifs;
+            if (readBinary) {
+                ifs = std::ifstream(inputFilename, std::ios::binary);
+            } else {
+                ifs = std::ifstream(inputFilename);
+            }
 
             if (!ifs.good()) {
                 throw std::invalid_argument("Cannot open serialized file: " + inputFilename);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -191,8 +191,13 @@ namespace dd {
 
         // generate |0...0> with n qubits
         vEdge makeZeroState(QubitCount n, std::size_t start = 0) {
-            assert(n + start <= nqubits);
-
+            if (n + start > nqubits) {
+                throw std::runtime_error("Requested state with " +
+                                         std::to_string(n + start) +
+                                         " qubits, but current package configuration only supports up to " +
+                                         std::to_string(nqubits) +
+                                         " qubits. Please allocate a larger package instance.");
+            }
             auto f = vEdge::one;
             for (std::size_t p = start; p < n + start; p++) {
                 f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
@@ -201,8 +206,13 @@ namespace dd {
         }
         // generate computational basis state |i> with n qubits
         vEdge makeBasisState(QubitCount n, const std::vector<bool>& state, std::size_t start = 0) {
-            assert(n + start <= nqubits);
-
+            if (n + start > nqubits) {
+                throw std::runtime_error("Requested state with " +
+                                         std::to_string(n + start) +
+                                         " qubits, but current package configuration only supports up to " +
+                                         std::to_string(nqubits) +
+                                         " qubits. Please allocate a larger package instance.");
+            }
             auto f = vEdge::one;
             for (std::size_t p = start; p < n + start; ++p) {
                 if (state[p] == 0) {
@@ -215,10 +225,15 @@ namespace dd {
         }
         // generate general basis state with n qubits
         vEdge makeBasisState(QubitCount n, const std::vector<BasisStates>& state, std::size_t start = 0) {
-            assert(n + start <= nqubits);
-
+            if (n + start > nqubits) {
+                throw std::runtime_error("Requested state with " +
+                                         std::to_string(n + start) +
+                                         " qubits, but current package configuration only supports up to " +
+                                         std::to_string(nqubits) +
+                                         " qubits. Please allocate a larger package instance.");
+            }
             if (state.size() < n) {
-                throw std::invalid_argument("Insufficient qubit states provided. Requested " + std::to_string(n) + ", but received " + std::to_string(state.size()));
+                throw std::runtime_error("Insufficient qubit states provided. Requested " + std::to_string(n) + ", but received " + std::to_string(state.size()));
             }
 
             auto f = vEdge::one;
@@ -360,8 +375,13 @@ namespace dd {
             return makeGateDD(mat, n, Controls{control}, target, start);
         }
         mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n, const Controls& controls, Qubit target, std::size_t start = 0) {
-            assert(n + start <= nqubits);
-
+            if (n + start > nqubits) {
+                throw std::runtime_error("Requested gate with " +
+                                         std::to_string(n + start) +
+                                         " qubits, but current package configuration only supports up to " +
+                                         std::to_string(nqubits) +
+                                         " qubits. Please allocate a larger package instance.");
+            }
             std::array<mEdge, NEDGE> em{};
             auto                     it = controls.begin();
             for (auto i = 0U; i < NEDGE; ++i) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2034,12 +2034,7 @@ namespace dd {
 
         template<class Node, class Edge = Edge<Node>>
         Edge deserialize(const std::string& inputFilename, bool readBinary) {
-            std::ifstream ifs;
-            if (readBinary) {
-                ifs = std::ifstream(inputFilename, std::ios::binary);
-            } else {
-                ifs = std::ifstream(inputFilename);
-            }
+            auto ifs = std::ifstream(inputFilename, std::ios::binary);
 
             if (!ifs.good()) {
                 throw std::invalid_argument("Cannot open serialized file: " + inputFilename);

--- a/test/test_complex.cpp
+++ b/test/test_complex.cpp
@@ -97,6 +97,10 @@ TEST(DDComplexTest, ComplexNumberArithmetic) {
     EXPECT_EQ(e, Complex::one);
     auto f = cn.getTemporary();
     ComplexNumbers::div(f, Complex::zero, Complex::one);
+
+    dd::ComplexValue zero{0., 0.};
+    dd::ComplexValue one{1., 0.};
+    EXPECT_EQ(one + zero, one);
 }
 
 TEST(DDComplexTest, NearZeroLookup) {

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -497,11 +497,15 @@ TEST(DDPackageTest, GarbageMatrix) {
     EXPECT_TRUE(reduced_bell_matrix.p->e[3].isZeroTerminal());
 }
 
-TEST(DDPackageTest, InvalidMakeBasisState) {
+TEST(DDPackageTest, InvalidMakeBasisStateAndGate) {
     auto nqubits    = 2;
     auto dd         = std::make_unique<dd::Package>(nqubits);
     auto basisState = std::vector<dd::BasisStates>{dd::BasisStates::zero};
-    EXPECT_THROW(dd->makeBasisState(nqubits, basisState), std::invalid_argument);
+    EXPECT_THROW(dd->makeBasisState(nqubits, basisState), std::runtime_error);
+    EXPECT_THROW(dd->makeZeroState(3), std::runtime_error);
+    EXPECT_THROW(dd->makeBasisState(3, {true, true, true}), std::runtime_error);
+    EXPECT_THROW(dd->makeBasisState(3, {dd::BasisStates::one, dd::BasisStates::one, dd::BasisStates::one}), std::runtime_error);
+    EXPECT_THROW(dd->makeGateDD(dd::Xmat, 3, 0), std::runtime_error);
 }
 
 TEST(DDPackageTest, InvalidDecRef) {

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -62,7 +62,7 @@ TEST(DDPackageTest, BellState) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
     auto zero_state = dd->makeZeroState(2);
 
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
@@ -148,7 +148,7 @@ TEST(DDPackageTest, VectorSerializationTest) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
     auto zero_state = dd->makeZeroState(2);
 
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
@@ -166,7 +166,7 @@ TEST(DDPackageTest, BellMatrix) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
 
@@ -219,7 +219,7 @@ TEST(DDPackageTest, MatrixSerializationTest) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate  = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
 
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
 
@@ -236,7 +236,7 @@ TEST(DDPackageTest, SerializationErrors) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
     auto zero_state = dd->makeZeroState(2);
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
 
@@ -282,7 +282,7 @@ TEST(DDPackageTest, TestConsistency) {
     auto dd = std::make_unique<dd::Package>(2);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 1);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1, 0);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
     auto zero_state = dd->makeZeroState(2);
 
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
@@ -374,7 +374,7 @@ TEST(DDPackageTest, TestLocalInconsistency) {
     auto dd = std::make_unique<dd::Package>(3);
 
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0, 1);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto zero_state = dd->makeZeroState(2);
 
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
@@ -400,7 +400,7 @@ TEST(DDPackageTest, TestLocalInconsistency) {
 TEST(DDPackageTest, Ancillaries) {
     auto dd          = std::make_unique<dd::Package>(4);
     auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0, 1);
+    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
 
     dd->incRef(bell_matrix);
@@ -437,7 +437,7 @@ TEST(DDPackageTest, Ancillaries) {
 TEST(DDPackageTest, GarbageVector) {
     auto dd         = std::make_unique<dd::Package>(4);
     auto h_gate     = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0, 1);
+    auto cx_gate    = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto zero_state = dd->makeZeroState(2);
     auto bell_state = dd->multiply(dd->multiply(cx_gate, h_gate), zero_state);
     dd->printVector(bell_state);
@@ -468,7 +468,7 @@ TEST(DDPackageTest, GarbageVector) {
 TEST(DDPackageTest, GarbageMatrix) {
     auto dd          = std::make_unique<dd::Package>(4);
     auto h_gate      = dd->makeGateDD(dd::Hmat, 2, 0);
-    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0, 1);
+    auto cx_gate     = dd->makeGateDD(dd::Xmat, 2, 0_pc, 1);
     auto bell_matrix = dd->multiply(cx_gate, h_gate);
 
     dd->incRef(bell_matrix);


### PR DESCRIPTION
This PR adds the essential functionality to the JKQ DD Package to support hybrid Schrödinger-Feynman simulation.
The main change is that decision diagrams might now "start" (from the bottom) with a different qubit than 0, which is needed for splitting the circuit horizontally.
Additionally, this PR adds functionality that allows to efficiently export a complete set of amplitudes from a state vector DD and to transfer an existing DD to another package instance.

✨ state generation, matrix generation, and multiplication receive an additional parameter `start` (default 0) that indicates the bottom-most qubit the DD is built from
💥 removed the `makeGateDD` constructor taking two `Qubit` arguments for control and target, as it is ambiguous with the new `start` parameter
✨ method for deleting a specific edge of a DD node
✨ `kronecker` receives an additional parameter indicating whether to increase the indices of the top DD
✨ method for tranfering a DD Edge from one package to another
✨ methods for (recursively) exporting and adding amplitudes
✨ ComplexValue addition
🏁 fix binary serialization issues under Windows
♻️ runtime exceptions instead of assertions
📝 fix readme example
📄 updated license