### PR TITLE
Use `std::complex` for vector and matrix output

### DIFF
--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -195,6 +195,8 @@ namespace dd {
             return ss.str();
         }
 
+        explicit operator auto() const { return std::complex<dd::fp>{r, i}; }
+
         ComplexValue& operator+=(const ComplexValue& rhs) {
             r += rhs.r;
             i += rhs.i;

--- a/include/dd/Definitions.hpp
+++ b/include/dd/Definitions.hpp
@@ -6,6 +6,7 @@
 #ifndef DDpackage_DATATYPES_HPP
 #define DDpackage_DATATYPES_HPP
 
+#include <complex>
 #include <cstdint>
 #include <type_traits>
 #include <utility>
@@ -49,8 +50,7 @@ namespace dd {
     static constexpr fp PI_2    = 1.570796326794896619231321691639751442098584699687552910487L;
     static constexpr fp PI_4    = 0.785398163397448309615660845819875721049292349843776455243L;
 
-    struct ComplexValue;
-    using CVec = std::vector<ComplexValue>;
+    using CVec = std::vector<std::complex<dd::fp>>;
     using CMat = std::vector<CVec>;
 
     static constexpr std::uint_least64_t SERIALIZATION_VERSION = 1;

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1906,34 +1906,6 @@ namespace dd {
             cn.returnToCache(c);
         }
 
-        std::vector<std::complex<fp>> getVectorStdComplex(const vEdge& e) {
-            std::size_t dim = 1 << (e.p->v + 1);
-            // allocate resulting vector
-            auto vec = std::vector<std::complex<fp>>(dim, {0.0, 0.0});
-            getVectorStdComplex(e, Complex::one, 0, vec);
-            return vec;
-        }
-        void getVectorStdComplex(const vEdge& e, const Complex& amp, std::size_t i, std::vector<std::complex<fp>>& vec) {
-            // calculate new accumulated amplitude
-            auto c = cn.mulCached(e.w, amp);
-
-            // base case
-            if (e.isTerminal()) {
-                vec.at(i) = {CTEntry::val(c.r), CTEntry::val(c.i)};
-                cn.returnToCache(c);
-                return;
-            }
-
-            std::size_t x = i | (1 << e.p->v);
-
-            // recursive case
-            if (!e.p->e[0].w.approximatelyZero())
-                getVectorStdComplex(e.p->e[0], c, i, vec);
-            if (!e.p->e[1].w.approximatelyZero())
-                getVectorStdComplex(e.p->e[1], c, x, vec);
-            cn.returnToCache(c);
-        }
-
         void printVector(const vEdge& e) {
             unsigned long long element = 2u << e.p->v;
             for (unsigned long long i = 0; i < element; i++) {

--- a/test/test_package.cpp
+++ b/test/test_package.cpp
@@ -476,15 +476,15 @@ TEST(DDPackageTest, GarbageVector) {
     reduced_bell_state = dd->reduceGarbage(bell_state, {false, true, false, false});
     auto vec           = dd->getVector(reduced_bell_state);
     dd->printVector(reduced_bell_state);
-    EXPECT_EQ(vec[2], dd::complex_zero);
-    EXPECT_EQ(vec[3], dd::complex_zero);
+    EXPECT_EQ(vec[2], static_cast<std::complex<dd::fp>>(dd::complex_zero));
+    EXPECT_EQ(vec[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 
     dd->incRef(bell_state);
     reduced_bell_state = dd->reduceGarbage(bell_state, {true, false, false, false});
     dd->printVector(reduced_bell_state);
     vec = dd->getVector(reduced_bell_state);
-    EXPECT_EQ(vec[1], dd::complex_zero);
-    EXPECT_EQ(vec[3], dd::complex_zero);
+    EXPECT_EQ(vec[1], static_cast<std::complex<dd::fp>>(dd::complex_zero));
+    EXPECT_EQ(vec[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 }
 
 TEST(DDPackageTest, GarbageMatrix) {
@@ -777,7 +777,7 @@ TEST(DDPackageTest, DestructiveMeasurementAll) {
     const dd::CVec vAfter = dd->getVector(plusState);
     const int      i      = std::stoi(m, nullptr, 2);
 
-    ASSERT_EQ(vAfter[i], dd::complex_one);
+    ASSERT_EQ(vAfter[i], static_cast<std::complex<dd::fp>>(dd::complex_one));
 }
 
 TEST(DDPackageTest, DestructiveMeasurementOne) {
@@ -795,18 +795,10 @@ TEST(DDPackageTest, DestructiveMeasurementOne) {
     const dd::CVec vAfter = dd->getVector(plusState);
 
     ASSERT_EQ(m, '0');
-    ASSERT_EQ(vAfter[0], dd::complex_SQRT2_2);
-    ASSERT_EQ(vAfter[2], dd::complex_SQRT2_2);
-    ASSERT_EQ(vAfter[1], dd::complex_zero);
-    ASSERT_EQ(vAfter[3], dd::complex_zero);
-
-    const auto vAfterCompl = dd->getVectorStdComplex(plusState);
-
-    assert(vAfter.size() == vAfterCompl.size());
-    for (std::size_t i = 0; i < vAfter.size(); i++) {
-        ASSERT_DOUBLE_EQ(vAfter.at(i).r, vAfterCompl.at(i).real());
-        ASSERT_DOUBLE_EQ(vAfter.at(i).i, vAfterCompl.at(i).imag());
-    }
+    ASSERT_EQ(vAfter[0], static_cast<std::complex<dd::fp>>(dd::complex_SQRT2_2));
+    ASSERT_EQ(vAfter[2], static_cast<std::complex<dd::fp>>(dd::complex_SQRT2_2));
+    ASSERT_EQ(vAfter[1], static_cast<std::complex<dd::fp>>(dd::complex_zero));
+    ASSERT_EQ(vAfter[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 }
 
 TEST(DDPackageTest, DestructiveMeasurementOneArbitraryNormalization) {
@@ -824,16 +816,8 @@ TEST(DDPackageTest, DestructiveMeasurementOneArbitraryNormalization) {
     const dd::CVec vAfter = dd->getVector(plusState);
 
     ASSERT_EQ(m, '0');
-    ASSERT_EQ(vAfter[0], dd::complex_SQRT2_2);
-    ASSERT_EQ(vAfter[2], dd::complex_SQRT2_2);
-    ASSERT_EQ(vAfter[1], dd::complex_zero);
-    ASSERT_EQ(vAfter[3], dd::complex_zero);
-
-    const auto vAfterCompl = dd->getVectorStdComplex(plusState);
-
-    assert(vAfter.size() == vAfterCompl.size());
-    for (std::size_t i = 0; i < vAfter.size(); i++) {
-        ASSERT_DOUBLE_EQ(vAfter.at(i).r, vAfterCompl.at(i).real());
-        ASSERT_DOUBLE_EQ(vAfter.at(i).i, vAfterCompl.at(i).imag());
-    }
+    ASSERT_EQ(vAfter[0], static_cast<std::complex<dd::fp>>(dd::complex_SQRT2_2));
+    ASSERT_EQ(vAfter[2], static_cast<std::complex<dd::fp>>(dd::complex_SQRT2_2));
+    ASSERT_EQ(vAfter[1], static_cast<std::complex<dd::fp>>(dd::complex_zero));
+    ASSERT_EQ(vAfter[3], static_cast<std::complex<dd::fp>>(dd::complex_zero));
 }


### PR DESCRIPTION
Up until now, our proprietary `ComplexValue` class was used for exporting vectors and matrices. This necessitates writing routines for dumping JSON representations thereof. This PR changes the respective typedefs to use the C++-native `std::complex` class.