### PR TITLE
Fix RZ gate matrix definition

### DIFF
--- a/include/dd/GateMatrixDefinitions.hpp
+++ b/include/dd/GateMatrixDefinitions.hpp
@@ -77,7 +77,7 @@ namespace dd {
     }
 
     inline GateMatrix RZmat(fp lambda) {
-        return GateMatrix{{{-std::cos(lambda / 2.), -std::sin(lambda / 2.)},
+        return GateMatrix{{{std::cos(lambda / 2.), -std::sin(lambda / 2.)},
                            complex_zero,
                            complex_zero,
                            {std::cos(lambda / 2.), std::sin(lambda / 2.)}}};


### PR DESCRIPTION
Due to unknown reasons the definition of the RZ gate matrix was wrong. 
This hasn't come up until now since OpenQASM's `qelib1.inc` translates `rz(...)` to `p(...)`, which is implemented correctly.
It only became apparent now due to IBM switching to the new `[rz, sx, cx]` gate set.