### PR TITLE
Test for compiler flag -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,12 @@ else ()
 	target_compile_options(${PROJECT_NAME} INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:DEBUG>:-Og>$<$<CONFIG:RELEASE>:-fno-math-errno -ffinite-math-only -fno-trapping-math>)
 	if (NOT DEPLOY)
 		# only include machine-specific optimizations when building for the host machine
-		target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native -march=native)
+		target_compile_options(${PROJECT_NAME} INTERFACE -mtune=native)
+		include(CheckCXXCompilerFlag)
+		check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
+		if (HAS_MARCH_NATIVE)
+			target_compile_options(${PROJECT_NAME} INTERFACE -march=native)
+		endif()
 	endif ()
 endif ()
 


### PR DESCRIPTION
Added a test in the CMakeLists.txt before adding the -march=native flag

The latest clang (clang-1300.0.29.30) on Apple M1 does not support it (yet?)

![image](https://user-images.githubusercontent.com/6476057/147471455-19d0140c-0935-4fe5-bb6c-630c2f81b7ab.png)
